### PR TITLE
Fix Action's ECR permissions and docker build invocation

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -34,5 +34,4 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           TAG: ${{ github.sha }}
-        run: |
-          ./build-push-images.sh
+        run: ./build-push-images.sh

--- a/build-push-images.sh
+++ b/build-push-images.sh
@@ -18,10 +18,13 @@ fi
 
 PLATFORM=linux/amd64
 
-STATIC_SERVER_REPO=connect-static-server
-API_SERVER_REPO=connect-api-server
+build() {
+  REPO=$1
+  DIR=$2
+  docker buildx build $DIR --tag $REGISTRY/$REPO:$TAG --platform $PLATFORM --push
+}
 
-docker buildx build frontend/   --tag $REGISTRY/$STATIC_SERVER_REPO:$TAG --platform $PLATFORM --push
-docker buildx build api-server/ --tag $REGISTRY/$API_SERVER_REPO:$TAG    --platform $PLATFORM --push 
+build connect-static-server frontend/
+build connect-api-server    api-server/
 
 docker image prune --force --filter "until=24h"

--- a/build-push-images.sh
+++ b/build-push-images.sh
@@ -21,12 +21,7 @@ PLATFORM=linux/amd64
 STATIC_SERVER_REPO=connect-static-server
 API_SERVER_REPO=connect-api-server
 
-docker buildx build frontend/   -t $STATIC_SERVER_REPO --platform $PLATFORM --tag $TAG
-docker buildx build api-server/ -t $API_SERVER_REPO    --platform $PLATFORM --tag $TAG
-
-for IMAGE_PATH in $STATIC_SERVER_REPO $API_SERVER_REPO; do
-  docker tag $IMAGE_PATH:$TAG $REGISTRY/$IMAGE_PATH:$TAG
-  docker push $REGISTRY/$IMAGE_PATH:$TAG
-done
+docker buildx build frontend/   --tag $REGISTRY/$STATIC_SERVER_REPO:$TAG --platform $PLATFORM --push
+docker buildx build api-server/ --tag $REGISTRY/$API_SERVER_REPO:$TAG    --platform $PLATFORM --push 
 
 docker image prune --force --filter "until=24h"

--- a/build-push-images.sh
+++ b/build-push-images.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+set -x
 
 if [ -z "${TAG:+x}" ]; then
   echo missing TAG variable >&2

--- a/terraform/github_actions.tf
+++ b/terraform/github_actions.tf
@@ -49,6 +49,14 @@ data "aws_iam_policy_document" "push_to_ecr_repos" {
   statement {
     effect = "Allow"
     actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "ecr:UploadLayerPart",
       "ecr:PutImage",
       "ecr:InitiateLayerUpload",
@@ -61,7 +69,6 @@ data "aws_iam_policy_document" "push_to_ecr_repos" {
       "ecr:ListImages",
       "ecr:BatchGetRepositoryScanningConfiguration",
       "ecr:DescribeRegistry",
-      "ecr:GetAuthorizationToken",
       "ecr:GetImageCopyStatus",
       "ecr:GetLifecyclePolicy",
       "ecr:GetLifecyclePolicyPreview",
@@ -74,10 +81,7 @@ data "aws_iam_policy_document" "push_to_ecr_repos" {
       "ecr:TagResource",
       "ecr:UntagResource"
     ]
-    resources = [
-      aws_ecr_repository.static_container_repo.arn,
-      aws_ecr_repository.api_server_container_repo.arn
-    ]
+    resources = [aws_ecr_repository.api_server_container_repo.arn, aws_ecr_repository.static_container_repo.arn]
   }
 }
 


### PR DESCRIPTION
- The action logs into ECR - which isn't associated with any specific resource - so the rule needs to have `resource: *`.
- The docker-build tool running in the action doesn't have an associated cluster, so we must directly upload to `--path`.
