### PR TITLE
Add CI step to check for TODO items in codebase

### DIFF
--- a/.github/workflows/check-no-todos.yaml
+++ b/.github/workflows/check-no-todos.yaml
@@ -12,7 +12,7 @@ jobs:
       
       - name: Grep for TODOs
         run: |
-          if git grep TODO ; then
+          if git grep TODO ':(exclude).github/workflows/check-no-todos.yaml' ; then
             echo found unadressed todo items >&2
             exit 1
           fi


### PR DESCRIPTION
Adds a simple CI stage that just runs `grep TODO`, and should block merging of PRs until these are addressed.